### PR TITLE
Rename boundActionCreators for Gatsby 3 compatibility.

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -113,8 +113,8 @@ function flattenJobPosts(jobs, jobPosts) {
   return flattenedJobPosts.filter((jobPost) => jobPost !== undefined)
 }
 
-exports.sourceNodes = async ({ boundActionCreators }, { apiToken, pluginOptions }) => {
-	const { createNode } = boundActionCreators
+exports.sourceNodes = async ({ actions }, { apiToken, pluginOptions }) => {
+	const { createNode } = actions
   const options = pluginOptions || defaultPluginOptions
 
   console.log(`Fetch Greenhouse data`)


### PR DESCRIPTION
https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/\#removal-of-boundactioncreators

See also https://github.com/diegolamanno/gatsby-source-greenhouse/pull/29

Merging this to see if I can create a release and use this as my source for the greenhouse source plugin.